### PR TITLE
Rewrite entity pipe character in JsonEntityId

### DIFF
--- a/akka-components/src/main/scala/ClusterComponent.scala
+++ b/akka-components/src/main/scala/ClusterComponent.scala
@@ -415,11 +415,17 @@ object ClusterComponent {
     trait JsonEntityId {
       _: ShardedT =>
 
+      /**
+       * The placeholder that will replace any | in the produced String as this character is illegal due to Akka's entityId encoding.
+       * When overriding keep the new placeholder permanently or existing entities won't be resolved.
+       * */
+      val barPlaceholder = "❘❘bar❘❘"
+
       implicit val entityIdCirceCodec: Codec[EntityId]
 
       implicit val entityIdCodec: EntityIdCodec[EntityId] = EntityIdCodec[EntityId](
-        _.asJson.noSpacesSortKeys,
-        _.pipe(parser.parse).flatMap(_.as[EntityId]).toTry
+        _.asJson.noSpacesSortKeys.replace("|", barPlaceholder),
+        _.replace(barPlaceholder, "|").pipe(parser.parse).flatMap(_.as[EntityId]).toTry
       )
     }
 

--- a/akka-components/src/main/scala/ClusterComponent.scala
+++ b/akka-components/src/main/scala/ClusterComponent.scala
@@ -418,6 +418,7 @@ object ClusterComponent {
       /**
        * The placeholder that will replace any | in the produced String as this character is illegal due to Akka's entityId encoding.
        * When overriding keep the new placeholder permanently or existing entities won't be resolved.
+       * The default value uses UTF-8 bars (from the Symbols palette in macOS).
        * */
       val barPlaceholder = "❘❘bar❘❘"
 

--- a/akka-components/src/test/scala/ClusterComponentSpec.scala
+++ b/akka-components/src/test/scala/ClusterComponentSpec.scala
@@ -255,11 +255,20 @@ class ClusterComponentSpec extends ScalaTestWithActorTestKit(ConfigFactory.parse
 
         val component = new ComponentObject.Component
         ComponentObject.init(component).delayedInit()
-        val entityRef = component.entityRefFor(ComponentObject.EntityId("a", "b"))
-        entityRef.entityId shouldBe """{"id1":"a","id2":"b"}"""
 
-        val entityRefWithPlaceholder = component.entityRefFor(ComponentObject.EntityId("a|b", "c|d"))
-        entityRefWithPlaceholder.entityId shouldBe """{"id1":"a❘❘bar❘❘b","id2":"c❘❘bar❘❘d"}"""
+        val expectedJson = """{"id1":"a","id2":"b"}"""
+        val abEntityId = ComponentObject.EntityId("a", "b")
+        val entityRef = component.entityRefFor(abEntityId)
+        entityRef.entityId shouldBe expectedJson
+        ComponentObject.entityIdCodec.encode(abEntityId) shouldBe expectedJson
+        ComponentObject.entityIdCodec.decode(expectedJson) shouldBe Success(abEntityId)
+
+        val expectedJsonWithPlaceholders = """{"id1":"a❘❘bar❘❘b","id2":"c❘❘bar❘❘d"}"""
+        val placeholdersEntityId = ComponentObject.EntityId("a|b", "c|d")
+        val entityRefWithPlaceholders = component.entityRefFor(placeholdersEntityId)
+        entityRefWithPlaceholders.entityId shouldBe expectedJsonWithPlaceholders
+        ComponentObject.entityIdCodec.encode(placeholdersEntityId) shouldBe expectedJsonWithPlaceholders
+        ComponentObject.entityIdCodec.decode(expectedJsonWithPlaceholders) shouldBe Success(placeholdersEntityId)
       }
       "custom json EntityId with custom placeholder" in {
         object ComponentObject extends ClusterComponent.Sharded with ClusterComponent.SameSerializableCommand with ClusterComponent.Sharded.JsonEntityId {
@@ -289,8 +298,12 @@ class ClusterComponentSpec extends ScalaTestWithActorTestKit(ConfigFactory.parse
 
         val component = new ComponentObject.Component
         ComponentObject.init(component).delayedInit()
-        val entityRefWithPlaceholder = component.entityRefFor(ComponentObject.EntityId("a|b", "c|d"))
-        entityRefWithPlaceholder.entityId shouldBe """{"id1":"a/b","id2":"c/d"}"""
+        val expectedJsonWithPlaceholders = """{"id1":"a/b","id2":"c/d"}"""
+        val placeholdersEntityId = ComponentObject.EntityId("a|b", "c|d")
+        val entityRefWithPlaceholder = component.entityRefFor(placeholdersEntityId)
+        entityRefWithPlaceholder.entityId shouldBe expectedJsonWithPlaceholders
+        ComponentObject.entityIdCodec.encode(placeholdersEntityId) shouldBe expectedJsonWithPlaceholders
+        ComponentObject.entityIdCodec.decode(expectedJsonWithPlaceholders) shouldBe Success(placeholdersEntityId)
       }
       "long EntityId" in {
         object ComponentObject extends ClusterComponent.Sharded with ClusterComponent.SameSerializableCommand with ClusterComponent.Sharded.LongEntityId {


### PR DESCRIPTION
Unfortunately cannot test if entity actually starts up. `entityRef.tell(Command())` also works when name is illegal.